### PR TITLE
add setRGB() function to manually overwrite LED color

### DIFF
--- a/MacRocketry_LED_Indicator.cpp
+++ b/MacRocketry_LED_Indicator.cpp
@@ -41,6 +41,11 @@ bool MacRocketry_LED_Indicator::setStatusSD(bool stats){
   return SD_Status;
 }
 
+void MacRocketry_LED_Indicator::setRGB(char r, char g, char b){
+  analogWrite(redPin, r);
+  analogWrite(greenPin, g);
+  analogWrite(bluePin, b);
+}
 
 void MacRocketry_LED_Indicator::displayLED(){
   switch (error){

--- a/MacRocketry_LED_Indicator.h
+++ b/MacRocketry_LED_Indicator.h
@@ -14,7 +14,8 @@ class MacRocketry_LED_Indicator {
     bool setStatusBMP(bool stats);  //check BMP error
     bool setStatusGPS(int fix);     //check GPS error
     bool setStatusSD(bool stats);   //check SD error
-
+    
+    void setRGB(char r, char g, char b);
     void displayLED(void);
     
   private:

--- a/examples/LED_Indicator_Lib/LED_Indicator_Lib.ino
+++ b/examples/LED_Indicator_Lib/LED_Indicator_Lib.ino
@@ -15,7 +15,8 @@ class MacRocketry_LED_Indicator {
     bool setStatusBMP(bool stats);  //check BMP error
     bool setStatusGPS(int fix);     //check GPS error
     bool setStatusSD(bool stats);   //check SD error
-
+    
+    void setRGB(char r, char g, char b);
     void displayLED(void);
     
   private:
@@ -72,6 +73,11 @@ bool MacRocketry_LED_Indicator::setStatusSD(bool stats){
   return SD_Status;
 }
 
+void MacRocketry_LED_Indicator::setRGB(char r, char g, char b){
+  analogWrite(redPin, r);
+  analogWrite(greenPin, g);
+  analogWrite(bluePin, b);
+}
 
 void MacRocketry_LED_Indicator::displayLED(){
   switch (error){


### PR DESCRIPTION
Function setRGB() can be used to manually overwrite LED color. Can be use during a state change as a way of displaying a state change visually.